### PR TITLE
Bug kbucket

### DIFF
--- a/apps/mob/src/kad/kbucket.erl
+++ b/apps/mob/src/kad/kbucket.erl
@@ -107,6 +107,8 @@ bucket_for(#kbucket{contacts = Contacts, peer = {_, MyId}}, {_, ContactId}) ->
     DestinationBucketIndex = bucket_index(distance(MyId, ContactId)),
     {DestinationBucketIndex, bucket(DestinationBucketIndex, Contacts)}.
 
+put_on([LeastContact | PartialBucket] = Bucket, LeastContact, #kbucket{k = K}) when length(Bucket) =:= K ->
+    PartialBucket ++ [LeastContact];
 put_on([LeastContact | PartialBucket] = Bucket, Contact, #kbucket{k = K, peer = Peer}) when length(Bucket) =:= K ->
     case peer:check_link(LeastContact, Peer) of
         ok -> Bucket;

--- a/apps/mob/test/kbucket.hrl
+++ b/apps/mob/test/kbucket.hrl
@@ -48,7 +48,9 @@ should_start_a_kbucket_process({KbucketPid, _}) ->
 
 should_create_a_bucket_if_not_exists({KbucketPid, _}) ->
     PeerContact = {self(), 2#1111},
+
     ok = kbucket:put(KbucketPid, PeerContact),
+
     [?_assertEqual([PeerContact], kbucket:get(KbucketPid, 1))].
 
 should_returns_an_empty_list_for_an_unknown_distance({KbucketPid, _}) ->
@@ -80,12 +82,12 @@ ping_the_least_seen_contact_when_a_bucket_is_full_and_remove_if_doesnt_respond({
     SixPeerContact   = {self(), 2#1011},
     SevenPeerContact = {self(), 2#1010},
     put_contacts(KbucketPid, [FourPeerContact, FivePeerContact, SixPeerContact]),
-
     meck:expect(peer, check_link,  ?two_any_args(?return(ko))),
+
     ok = kbucket:put(KbucketPid, SevenPeerContact),
 
-    [?_assertEqual([FivePeerContact, SixPeerContact, SevenPeerContact],
-                   kbucket:get(KbucketPid, 2))].
+    ExpectedBucket = [FivePeerContact, SixPeerContact, SevenPeerContact],
+    [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2))].
 
 ping_the_least_seen_contact_when_a_bucket_is_full_and_mantain_it_if_respond({KbucketPid, _}) ->
     FourPeerContact  = peer:start(2#1001, 3, ?ALPHA),
@@ -93,12 +95,12 @@ ping_the_least_seen_contact_when_a_bucket_is_full_and_mantain_it_if_respond({Kbu
     SixPeerContact   = {self(), 2#1011},
     SevenPeerContact = {self(), 2#1010},
     put_contacts(KbucketPid, [FourPeerContact, FivePeerContact, SixPeerContact]),
-
     meck:expect(peer, check_link, ?two_any_args(?return(ok))),
+
     ok = kbucket:put(KbucketPid, SevenPeerContact),
 
-    [?_assertEqual([FourPeerContact, FivePeerContact, SixPeerContact],
-                   kbucket:get(KbucketPid, 2))].
+    ExpectedBucket = [FourPeerContact, FivePeerContact, SixPeerContact],
+    [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2))].
 
 should_returns_up_to_k_contacts_closest_to_a_key({KbucketPid, _}) ->
     ThreePeerContact  = {self(), 2#1001},
@@ -106,8 +108,9 @@ should_returns_up_to_k_contacts_closest_to_a_key({KbucketPid, _}) ->
     OnePeerContact    = {self(), 2#1011},
     put_contacts(KbucketPid, [OnePeerContact, TwoPeerContact, ThreePeerContact]),
 
-    [?_assertEqual([OnePeerContact, TwoPeerContact, ThreePeerContact],
-                   kbucket:closest_contacts(KbucketPid, 2#1010))].
+    ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1010),
+
+    [?_assertEqual([OnePeerContact, TwoPeerContact, ThreePeerContact], ClosestContacts)].
 
 should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full({KbucketPid, _}) ->
     FivePeerContact   = {self(), 2#1111},
@@ -115,15 +118,15 @@ should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full({K
     TwoPeerContact    = {self(), 2#1000},
     put_contacts(KbucketPid, [TwoPeerContact, ThreePeerContact, FivePeerContact]),
 
-    [?_assertEqual([TwoPeerContact, ThreePeerContact, FivePeerContact],
-                   kbucket:closest_contacts(KbucketPid, 2#1010))].
+    ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1010),
+
+    [?_assertEqual([TwoPeerContact, ThreePeerContact, FivePeerContact], ClosestContacts)].
 
 should_search_a_key_within_each_bucket_and_refresh_its_content({KbucketPid, Peer}) ->
     ZeroBucketContact  = {self(), 12},
     OneBucketContact   = {self(), 15},
     TwoBucketContact   = {self(),  9},
     ThreeBucketContact = {self(),  5},
-
     AllContacts = [ZeroBucketContact, OneBucketContact, TwoBucketContact, ThreeBucketContact],
     meck:expect(peer, iterative_find_peers, fun(_, Key) ->
                                                 case Key of
@@ -135,10 +138,11 @@ should_search_a_key_within_each_bucket_and_refresh_its_content({KbucketPid, Peer
                                             end),
 
     kbucket:refresh(KbucketPid),
+
     timer:sleep(50),
-    [?_assertEqual([ZeroBucketContact], kbucket:get(KbucketPid, 0)),
-     ?_assertEqual([OneBucketContact], kbucket:get(KbucketPid, 1)),
-     ?_assertEqual([TwoBucketContact], kbucket:get(KbucketPid, 2)),
+    [?_assertEqual([ZeroBucketContact],  kbucket:get(KbucketPid, 0)),
+     ?_assertEqual([OneBucketContact],   kbucket:get(KbucketPid, 1)),
+     ?_assertEqual([TwoBucketContact],   kbucket:get(KbucketPid, 2)),
      ?_assertEqual([ThreeBucketContact], kbucket:get(KbucketPid, 3))].
 
 put_contacts(KbucketPid, []) ->

--- a/apps/mob/test/kbucket.hrl
+++ b/apps/mob/test/kbucket.hrl
@@ -123,27 +123,23 @@ should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full({K
     [?_assertEqual([TwoPeerContact, ThreePeerContact, FivePeerContact], ClosestContacts)].
 
 should_search_a_key_within_each_bucket_and_refresh_its_content({KbucketPid, Peer}) ->
-    ZeroBucketContact  = {self(), 12},
-    OneBucketContact   = {self(), 15},
-    TwoBucketContact   = {self(),  9},
-    ThreeBucketContact = {self(),  5},
-    AllContacts = [ZeroBucketContact, OneBucketContact, TwoBucketContact, ThreeBucketContact],
-    meck:expect(peer, iterative_find_peers, fun(_, Key) ->
-                                                case Key of
-                                                    12 -> AllContacts;
-                                                    15 -> AllContacts;
-                                                     9 -> AllContacts;
-                                                     5 -> AllContacts
-                                                end
-                                            end),
+    ZeroBucketContactId   = 12,
+    OneBucketContactId    = 15,
+    SecondBucketContactId = 9,
+    ThirdBucketContactId  = 5,
+    meck:expect(peer, iterative_find_peers, fun always_successful_iterative_find_peers/2),
 
     kbucket:refresh(KbucketPid),
 
     timer:sleep(50),
-    [?_assertEqual([ZeroBucketContact],  kbucket:get(KbucketPid, 0)),
-     ?_assertEqual([OneBucketContact],   kbucket:get(KbucketPid, 1)),
-     ?_assertEqual([TwoBucketContact],   kbucket:get(KbucketPid, 2)),
-     ?_assertEqual([ThreeBucketContact], kbucket:get(KbucketPid, 3))].
+    [?_assertMatch([{_, ZeroBucketContactId}],   kbucket:get(KbucketPid, 0)),
+     ?_assertMatch([{_, OneBucketContactId}],    kbucket:get(KbucketPid, 1)),
+     ?_assertMatch([{_, SecondBucketContactId}], kbucket:get(KbucketPid, 2)),
+     ?_assertMatch([{_, ThirdBucketContactId}],  kbucket:get(KbucketPid, 3))].
+
+always_successful_iterative_find_peers(_, Key) ->
+    FakeSearchedContact = {self(), Key},
+    [FakeSearchedContact].
 
 put_contacts(KbucketPid, []) ->
     ok;

--- a/apps/mob/test/kbucket.hrl
+++ b/apps/mob/test/kbucket.hrl
@@ -50,7 +50,8 @@ peer_suite_test_() ->
      ?setup(fun do_not_ping_the_least_seen_contact_if_it_is_the_same_to_put_but_update_it/1),
      ?setup(fun should_returns_an_empty_list_for_an_unknown_distance/1),
      ?setup(fun should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full/1),
-     ?setup(fun should_returns_up_to_k_contacts_closest_to_a_key/1),
+     ?setup(fun should_returns_the_k_contacts_closest_to_a_key/1),
+     ?setup(fun should_returns_less_than_k_contacts_if_not_all_available/1),
      ?setup(fun should_search_a_key_within_each_bucket_and_refresh_its_content/1)].
 
 should_compute_the_distance_of_two_id_test() ->
@@ -117,8 +118,8 @@ do_not_ping_the_least_seen_contact_if_it_is_the_same_to_put_but_update_it({Kbuck
     [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2)),
      ?_assertEqual(0, meck:num_calls(peer, check_link, [?TWO_PEER_1, Peer]))].
 
-should_returns_up_to_k_contacts_closest_to_a_key({KbucketPid, _}) ->
-    put_contacts(KbucketPid, [?TWO_PEER_3, ?TWO_PEER_2, ?TWO_PEER_1]),
+should_returns_the_k_contacts_closest_to_a_key({KbucketPid, _}) ->
+    put_contacts(KbucketPid, [?THIRD_PEER_1, ?TWO_PEER_3, ?TWO_PEER_2, ?TWO_PEER_1]),
 
     ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1101),
 
@@ -130,6 +131,13 @@ should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full({K
     ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1010),
 
     [?_assertEqual([?TWO_PEER_2, ?TWO_PEER_1, ?ONE_PEER_1], ClosestContacts)].
+
+should_returns_less_than_k_contacts_if_not_all_available({KbucketPid, _}) ->
+    put_contacts(KbucketPid, [?TWO_PEER_1, ?ONE_PEER_1]),
+
+    ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1010),
+
+    [?_assertEqual([?TWO_PEER_1, ?ONE_PEER_1], ClosestContacts)].
 
 should_search_a_key_within_each_bucket_and_refresh_its_content({KbucketPid, _}) ->
     meck:expect(peer, iterative_find_peers, fun always_successful_iterative_find_peers/2),

--- a/apps/mob/test/kbucket.hrl
+++ b/apps/mob/test/kbucket.hrl
@@ -46,6 +46,7 @@ peer_suite_test_() ->
      ?setup(fun should_update_an_already_present_contacts/1),
      ?setup(fun ping_the_least_seen_contact_when_a_bucket_is_full_and_remove_if_doesnt_respond/1),
      ?setup(fun ping_the_least_seen_contact_when_a_bucket_is_full_and_mantain_it_if_respond/1),
+     ?setup(fun do_not_ping_the_least_seen_contact_if_it_is_the_same_to_put_but_update_it/1),
      ?setup(fun should_returns_an_empty_list_for_an_unknown_distance/1),
      ?setup(fun should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full/1),
      ?setup(fun should_returns_up_to_k_contacts_closest_to_a_key/1),
@@ -105,6 +106,15 @@ ping_the_least_seen_contact_when_a_bucket_is_full_and_mantain_it_if_respond({Kbu
 
     ExpectedBucket = [?TWO_PEER_1, ?TWO_PEER_2, ?TWO_PEER_3],
     [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2))].
+
+do_not_ping_the_least_seen_contact_if_it_is_the_same_to_put_but_update_it({KbucketPid, Peer}) ->
+    put_contacts(KbucketPid, [?TWO_PEER_1, ?TWO_PEER_2, ?TWO_PEER_3]),
+
+    ok = kbucket:put(KbucketPid, ?TWO_PEER_1),
+
+    ExpectedBucket = [?TWO_PEER_2, ?TWO_PEER_3, ?TWO_PEER_1],
+    [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2)),
+     ?_assertEqual(0, meck:num_calls(peer, check_link, [?TWO_PEER_1, Peer]))].
 
 should_returns_up_to_k_contacts_closest_to_a_key({KbucketPid, _}) ->
     put_contacts(KbucketPid, [?TWO_PEER_3, ?TWO_PEER_2, ?TWO_PEER_1]),

--- a/apps/mob/test/kbucket.hrl
+++ b/apps/mob/test/kbucket.hrl
@@ -56,18 +56,16 @@ should_returns_an_empty_list_for_an_unknown_distance({KbucketPid, _}) ->
 
 should_append_a_contacts_with_the_same_bucket_index({KbucketPid, _}) ->
     PeerContact    = {self(), 2#1111}, % distance of 2 from OwningId
-    AnotherContact = {self(), 2#1110}, %distance of 3 from OwningId
+    AnotherContact = {self(), 2#1110}, % distance of 3 from OwningId
 
-    ok = kbucket:put(KbucketPid, PeerContact),
-    ok = kbucket:put(KbucketPid, AnotherContact),
+    put_contacts(KbucketPid, [PeerContact, AnotherContact]),
 
     [?_assertEqual([PeerContact, AnotherContact], kbucket:get(KbucketPid, 1))].
 
 should_update_an_already_present_contacts({KbucketPid, _}) ->
     PeerContact    = {self(), 2#1111},
     AnotherContact = {self(), 2#1110},
-    ok = kbucket:put(KbucketPid, PeerContact),
-    ok = kbucket:put(KbucketPid, AnotherContact),
+    put_contacts(KbucketPid, [PeerContact, AnotherContact]),
 
     ok = kbucket:put(KbucketPid, PeerContact),
 
@@ -81,10 +79,7 @@ ping_the_least_seen_contact_when_a_bucket_is_full_and_remove_if_doesnt_respond({
     FivePeerContact  = {self(), 2#1000},
     SixPeerContact   = {self(), 2#1011},
     SevenPeerContact = {self(), 2#1010},
-
-    ok = kbucket:put(KbucketPid, FourPeerContact),
-    ok = kbucket:put(KbucketPid, FivePeerContact),
-    ok = kbucket:put(KbucketPid,  SixPeerContact),
+    put_contacts(KbucketPid, [FourPeerContact, FivePeerContact, SixPeerContact]),
 
     meck:expect(peer, check_link,  ?two_any_args(?return(ko))),
     ok = kbucket:put(KbucketPid, SevenPeerContact),
@@ -97,10 +92,7 @@ ping_the_least_seen_contact_when_a_bucket_is_full_and_mantain_it_if_respond({Kbu
     FivePeerContact  = {self(), 2#1000},
     SixPeerContact   = {self(), 2#1011},
     SevenPeerContact = {self(), 2#1010},
-
-    ok = kbucket:put(KbucketPid, FourPeerContact),
-    ok = kbucket:put(KbucketPid, FivePeerContact),
-    ok = kbucket:put(KbucketPid,  SixPeerContact),
+    put_contacts(KbucketPid, [FourPeerContact, FivePeerContact, SixPeerContact]),
 
     meck:expect(peer, check_link, ?two_any_args(?return(ok))),
     ok = kbucket:put(KbucketPid, SevenPeerContact),
@@ -112,10 +104,7 @@ should_returns_up_to_k_contacts_closest_to_a_key({KbucketPid, _}) ->
     ThreePeerContact  = {self(), 2#1001},
     TwoPeerContact    = {self(), 2#1000},
     OnePeerContact    = {self(), 2#1011},
-
-    ok = kbucket:put(KbucketPid,    OnePeerContact),
-    ok = kbucket:put(KbucketPid,    TwoPeerContact),
-    ok = kbucket:put(KbucketPid,  ThreePeerContact),
+    put_contacts(KbucketPid, [OnePeerContact, TwoPeerContact, ThreePeerContact]),
 
     [?_assertEqual([OnePeerContact, TwoPeerContact, ThreePeerContact],
                    kbucket:closest_contacts(KbucketPid, 2#1010))].
@@ -124,10 +113,7 @@ should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full({K
     FivePeerContact   = {self(), 2#1111},
     ThreePeerContact  = {self(), 2#1001},
     TwoPeerContact    = {self(), 2#1000},
-
-    ok = kbucket:put(KbucketPid,   TwoPeerContact),
-    ok = kbucket:put(KbucketPid, ThreePeerContact),
-    ok = kbucket:put(KbucketPid,  FivePeerContact),
+    put_contacts(KbucketPid, [TwoPeerContact, ThreePeerContact, FivePeerContact]),
 
     [?_assertEqual([TwoPeerContact, ThreePeerContact, FivePeerContact],
                    kbucket:closest_contacts(KbucketPid, 2#1010))].
@@ -154,3 +140,9 @@ should_search_a_key_within_each_bucket_and_refresh_its_content({KbucketPid, Peer
      ?_assertEqual([OneBucketContact], kbucket:get(KbucketPid, 1)),
      ?_assertEqual([TwoBucketContact], kbucket:get(KbucketPid, 2)),
      ?_assertEqual([ThreeBucketContact], kbucket:get(KbucketPid, 3))].
+
+put_contacts(KbucketPid, []) ->
+    ok;
+put_contacts(KbucketPid, [Contact | Contacts]) ->
+    ok = kbucket:put(KbucketPid, Contact),
+    put_contacts(KbucketPid, Contacts).

--- a/apps/mob/test/kbucket.hrl
+++ b/apps/mob/test/kbucket.hrl
@@ -5,6 +5,28 @@
 -define(ID_LENGTH, 4).
 -define(ALPHA, 3).
 
+% build a fake peer with the specified ID and fixed (dummy) PID
+-define(FAKE_PEER(ID), {list_to_pid("<0.255.255>"), ID}).
+
+% fake peers.
+% the IDs are such that their Bucket Index are those specified
+% on the prefix of the name (ZERO, ONE, ...) if stored in a
+% peer with ID 2#1101 (?PEER_ID). On the same bucket index, the
+% fake peers are sorted on distance (so _1 is closer than _2)
+%
+%                                           DISTANCE
+-define(ZERO_PEER_1, ?FAKE_PEER(2#1100)).  % 1
+
+-define(ONE_PEER_1,  ?FAKE_PEER(2#1111)).  % 2
+-define(ONE_PEER_2,  ?FAKE_PEER(2#1110)).  % 3
+
+-define(TWO_PEER_1,  ?FAKE_PEER(2#1001)).  % 4
+-define(TWO_PEER_2,  ?FAKE_PEER(2#1000)).  % 5
+-define(TWO_PEER_3,  ?FAKE_PEER(2#1011)).  % 6
+-define(TWO_PEER_4,  ?FAKE_PEER(2#1010)).  % 7
+
+-define(THIRD_PEER_1, ?FAKE_PEER(2#0101)). % 10
+
 start() ->
     meck:new(peer),
     meck:expect(peer, start, fun(Id, Kbucket, Alpha) -> {self(), Id} end),
@@ -47,99 +69,70 @@ should_start_a_kbucket_process({KbucketPid, _}) ->
     [?_assert(erlang:is_pid(KbucketPid))].
 
 should_create_a_bucket_if_not_exists({KbucketPid, _}) ->
-    PeerContact = {self(), 2#1111},
+    ok = kbucket:put(KbucketPid, ?ONE_PEER_1),
 
-    ok = kbucket:put(KbucketPid, PeerContact),
-
-    [?_assertEqual([PeerContact], kbucket:get(KbucketPid, 1))].
+    [?_assertEqual([?ONE_PEER_1], kbucket:get(KbucketPid, 1))].
 
 should_returns_an_empty_list_for_an_unknown_distance({KbucketPid, _}) ->
     [?_assertEqual([], kbucket:get(KbucketPid, 100))].
 
 should_append_a_contacts_with_the_same_bucket_index({KbucketPid, _}) ->
-    PeerContact    = {self(), 2#1111}, % distance of 2 from OwningId
-    AnotherContact = {self(), 2#1110}, % distance of 3 from OwningId
+    put_contacts(KbucketPid, [?ONE_PEER_1, ?ONE_PEER_2]),
 
-    put_contacts(KbucketPid, [PeerContact, AnotherContact]),
-
-    [?_assertEqual([PeerContact, AnotherContact], kbucket:get(KbucketPid, 1))].
+    [?_assertEqual([?ONE_PEER_1, ?ONE_PEER_2], kbucket:get(KbucketPid, 1))].
 
 should_update_an_already_present_contacts({KbucketPid, _}) ->
-    PeerContact    = {self(), 2#1111},
-    AnotherContact = {self(), 2#1110},
-    put_contacts(KbucketPid, [PeerContact, AnotherContact]),
+    put_contacts(KbucketPid, [?ONE_PEER_1, ?ONE_PEER_2]),
 
-    ok = kbucket:put(KbucketPid, PeerContact),
+    ok = kbucket:put(KbucketPid, ?ONE_PEER_1),
 
-    [?_assertEqual([AnotherContact, PeerContact], kbucket:get(KbucketPid, 1))].
+    [?_assertEqual([?ONE_PEER_2, ?ONE_PEER_1], kbucket:get(KbucketPid, 1))].
 
 ping_the_least_seen_contact_when_a_bucket_is_full_and_remove_if_doesnt_respond({KbucketPid, _}) ->
-    % these defines fakes contacts.
-    % the IDs are such that its BucketIndex are the
-    % same if stored in a peer with 2#1101 ID.
-    FourPeerContact  = peer:start(2#1001, 3, ?ALPHA),
-    FivePeerContact  = {self(), 2#1000},
-    SixPeerContact   = {self(), 2#1011},
-    SevenPeerContact = {self(), 2#1010},
-    put_contacts(KbucketPid, [FourPeerContact, FivePeerContact, SixPeerContact]),
     meck:expect(peer, check_link,  ?two_any_args(?return(ko))),
+    put_contacts(KbucketPid, [?TWO_PEER_1, ?TWO_PEER_2, ?TWO_PEER_3]),
 
-    ok = kbucket:put(KbucketPid, SevenPeerContact),
+    ok = kbucket:put(KbucketPid, ?TWO_PEER_4),
 
-    ExpectedBucket = [FivePeerContact, SixPeerContact, SevenPeerContact],
+    ExpectedBucket = [?TWO_PEER_2, ?TWO_PEER_3, ?TWO_PEER_4],
     [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2))].
 
 ping_the_least_seen_contact_when_a_bucket_is_full_and_mantain_it_if_respond({KbucketPid, _}) ->
-    FourPeerContact  = peer:start(2#1001, 3, ?ALPHA),
-    FivePeerContact  = {self(), 2#1000},
-    SixPeerContact   = {self(), 2#1011},
-    SevenPeerContact = {self(), 2#1010},
-    put_contacts(KbucketPid, [FourPeerContact, FivePeerContact, SixPeerContact]),
+    put_contacts(KbucketPid, [?TWO_PEER_1, ?TWO_PEER_2, ?TWO_PEER_3]),
     meck:expect(peer, check_link, ?two_any_args(?return(ok))),
 
-    ok = kbucket:put(KbucketPid, SevenPeerContact),
+    ok = kbucket:put(KbucketPid, ?TWO_PEER_4),
 
-    ExpectedBucket = [FourPeerContact, FivePeerContact, SixPeerContact],
+    ExpectedBucket = [?TWO_PEER_1, ?TWO_PEER_2, ?TWO_PEER_3],
     [?_assertEqual(ExpectedBucket, kbucket:get(KbucketPid, 2))].
 
 should_returns_up_to_k_contacts_closest_to_a_key({KbucketPid, _}) ->
-    ThreePeerContact  = {self(), 2#1001},
-    TwoPeerContact    = {self(), 2#1000},
-    OnePeerContact    = {self(), 2#1011},
-    put_contacts(KbucketPid, [OnePeerContact, TwoPeerContact, ThreePeerContact]),
+    put_contacts(KbucketPid, [?TWO_PEER_3, ?TWO_PEER_2, ?TWO_PEER_1]),
 
-    ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1010),
+    ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1101),
 
-    [?_assertEqual([OnePeerContact, TwoPeerContact, ThreePeerContact], ClosestContacts)].
+    [?_assertEqual([?TWO_PEER_1, ?TWO_PEER_2, ?TWO_PEER_3], ClosestContacts)].
 
 should_fill_the_results_with_other_contacts_if_the_closest_bucket_is_not_full({KbucketPid, _}) ->
-    FivePeerContact   = {self(), 2#1111},
-    ThreePeerContact  = {self(), 2#1001},
-    TwoPeerContact    = {self(), 2#1000},
-    put_contacts(KbucketPid, [TwoPeerContact, ThreePeerContact, FivePeerContact]),
+    put_contacts(KbucketPid, [?TWO_PEER_2, ?TWO_PEER_1, ?ONE_PEER_1]),
 
     ClosestContacts = kbucket:closest_contacts(KbucketPid, 2#1010),
 
-    [?_assertEqual([TwoPeerContact, ThreePeerContact, FivePeerContact], ClosestContacts)].
+    [?_assertEqual([?TWO_PEER_2, ?TWO_PEER_1, ?ONE_PEER_1], ClosestContacts)].
 
 should_search_a_key_within_each_bucket_and_refresh_its_content({KbucketPid, Peer}) ->
-    ZeroBucketContactId   = 12,
-    OneBucketContactId    = 15,
-    SecondBucketContactId = 9,
-    ThirdBucketContactId  = 5,
     meck:expect(peer, iterative_find_peers, fun always_successful_iterative_find_peers/2),
 
     kbucket:refresh(KbucketPid),
 
     timer:sleep(50),
-    [?_assertMatch([{_, ZeroBucketContactId}],   kbucket:get(KbucketPid, 0)),
-     ?_assertMatch([{_, OneBucketContactId}],    kbucket:get(KbucketPid, 1)),
-     ?_assertMatch([{_, SecondBucketContactId}], kbucket:get(KbucketPid, 2)),
-     ?_assertMatch([{_, ThirdBucketContactId}],  kbucket:get(KbucketPid, 3))].
+    [?_assertEqual([?ZERO_PEER_1],  kbucket:get(KbucketPid, 0)),
+     ?_assertEqual([?ONE_PEER_1],   kbucket:get(KbucketPid, 1)),
+     ?_assertEqual([?TWO_PEER_1],   kbucket:get(KbucketPid, 2)),
+     ?_assertEqual([?THIRD_PEER_1], kbucket:get(KbucketPid, 3))].
 
 always_successful_iterative_find_peers(_, Key) ->
-    FakeSearchedContact = {self(), Key},
-    [FakeSearchedContact].
+    [?FAKE_PEER(Key)].
 
 put_contacts(KbucketPid, []) ->
     ok;


### PR DESCRIPTION
When a bucket is full and another contact has to be inserted on the same bucket, we `PING` the least seen contact (through `peer:check_link`) to see if it is alive and optionally we adds the contact. When the least seen contact is the same that we want to put, we can avoid to check if it is alive, since the `kbucket:put()` is meant to put the peer that make a request (so it is "necessarily" alive). 
If we instead `PING` the peer we can end up in situations in which the peer is unable to reply with a `PONG` just because it is busy on the request that caused  this `PUT` to happen (not necessarily all requests are async), wasting time to wait a reply, or - more seriously - create endless loops: the peer that makes the request answers with `PONG`, that triggers another `PUT`, that trigger another `PING` (since it is still the least seen), that could generate another `PONG`, etc etc. This is handled with this [unit test](https://github.com/mobos/mob/commit/1dbef4e2b287fcf0338aba1243426260cde2811e)
, I will see if we can test the entire scenario.

Other commits are refactoring on the kbucket test suite only, that I hope make it more clear and concise.
